### PR TITLE
Allow negative numbers in arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,11 @@ use ustr::ustr;
 #[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
+	#[arg(allow_negative_numbers(true))]
 	x: f32,
+	#[arg(allow_negative_numbers(true))]
 	y: f32,
+	#[arg(allow_negative_numbers(true))]
 	z: f32,
 	#[clap(short = 'r')]
 	yaw: Option<f32>,


### PR DESCRIPTION
By default, clap interprets arguments starting with a hyphen as flags and thus would error when passing negative numbers as the X, Y or Z value.